### PR TITLE
Add functionality to fetch gold rates from API and store in Firestore

### DIFF
--- a/src/pages/admin/Admin.js
+++ b/src/pages/admin/Admin.js
@@ -3,6 +3,9 @@ import { doc, updateDoc } from "firebase/firestore";
 import { db } from "../../firebase/Firebase";
 import './Admin.css';
 
+const DOCUMENT_ID = "GF8lmn4pjyeuqPzA0xDE";
+const API_URL = "https://www.businessmantra.info/gold_rates/devi_gold_rate/api.php";
+
 const Admin = () => {
   const [rates, setRates] = useState({
     vedhani: "",
@@ -10,6 +13,7 @@ const Admin = () => {
     ornaments18K: "",
     silver: "",
   });
+  const [loading, setLoading] = useState(false);
 
   const handleChange = (e) => {
     const { name, value } = e.target;
@@ -23,8 +27,7 @@ const Admin = () => {
     e.preventDefault();
 
     try {
-      const documentId = "GF8lmn4pjyeuqPzA0xDE";
-      const documentRef = doc(db, "rates", documentId);
+      const documentRef = doc(db, "rates", DOCUMENT_ID);
 
       await updateDoc(documentRef, rates);
       alert("Rates updated successfully!");
@@ -40,9 +43,48 @@ const Admin = () => {
     }
   };
 
+  const fetchAndSaveRates = async () => {
+    try {
+      setLoading(true);
+      const res = await fetch(API_URL);
+      if (!res.ok) {
+        throw new Error(`API responded with status ${res.status}`);
+      }
+      const data = await res.json();
+      // Map API fields to our Firestore schema
+      const mapped = {
+        vedhani: data["24K Gold"] ?? "",
+        ornaments22K: data["22K Gold"] ?? "",
+        ornaments18K: data["18K Gold"] ?? "",
+        silver: data["Silver"] ?? "",
+      };
+
+      // Update UI with fetched values
+      setRates(mapped);
+
+      // Persist to Firestore
+      const documentRef = doc(db, "rates", DOCUMENT_ID);
+      await updateDoc(documentRef, mapped);
+
+      alert("Fetched latest rates from API and saved to database.");
+    } catch (error) {
+      console.error("Failed to fetch/save rates from API:", error);
+      alert("Failed to fetch/save rates from API.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
   return (
     <div className="admin-page-container">
       <h2>Upload Current Rates</h2>
+
+      <div style={{ marginBottom: 16 }}>
+        <button type="button" onClick={fetchAndSaveRates} disabled={loading}>
+          {loading ? "Fetching..." : "Fetch from API and Save"}
+        </button>
+      </div>
+
       <form onSubmit={handleSubmit}>
         <div className="form-group">
           <label>Vedhani (10 grams):</label>


### PR DESCRIPTION
This PR introduces the ability to fetch the latest gold and silver rates from an external API (`https://www.businessmantra.info/gold_rates/devi_gold_rate/api.php`) and store these rates in Firestore. The changes include a new function `fetchAndSaveRates` that retrieves data from the API, maps the received fields to our Firestore schema, and updates the UI accordingly. A button to trigger this function has also been added to the admin page, allowing users to manually refresh the rates. Additionally, loading states are managed to improve user experience.

---

> This pull request was co-created with Cosine Genie

Original Task: [DEVIWEbsite/oh3wnvsy3xyn](https://cosine.sh/znudrvw3hn93/DEVIWEbsite/task/oh3wnvsy3xyn)
Author: ipadyptab
